### PR TITLE
add useUnique feature for buffering last status data

### DIFF
--- a/lib/buffering.js
+++ b/lib/buffering.js
@@ -13,6 +13,7 @@ function Buffering(options) {
     this._data = (this._useUnique) ? {} : [];
     this._objectLength = 0;
     this._flushQueue = [];
+    this._flushQueueSize = 0;
     this._flushTimer = null;
     this._paused = false;
     this._resumeTimer = null;
@@ -80,18 +81,41 @@ Buffering.prototype.enqueue = function(data) {
 
 Buffering.prototype.undequeue = function(data) {
     if (!(data instanceof Array)) data = [data];
-    this._flushQueue.unshift.apply(this._flushQueue, data);
+    this._flushQueue.push(data);
+    this._flushQueueSize += data.length;
     this._checkAndFlush();
 };
 
 Buffering.prototype.flush = function() {
-    var data;
+    var data = [];
+    var size, tmp;
     if (!this._paused) {
-        if (this._flushQueue.length > 0) {
-            data = this._flushQueue.shift();
-        } else {
-            var size = (this._sizeThreshold > 0) ? this._sizeThreshold : this.size();
-            data = (this._useUnique) ? this._getDataUnique(size) : this._data.splice(0, size);
+        var size = (this._sizeThreshold > 0) ? this._sizeThreshold : -1;
+
+        while (this._flushQueue.length) {
+            if (size > 0) {
+                tmp = this._flushQueue.pop();
+                this._flushQueueSize -= tmp.length;
+                size -= tmp.length;
+                if (size < 0) {
+                    this._flushQueue.push(tmp.splice(size, Math.abs(size)));
+                    this._flushQueueSize -= size; // add back
+                    size = 0;
+                }
+                data.push.apply(data, tmp);
+                if (size === 0) {
+                    break;
+                }
+            } else {
+                data.push.apply(data, this._flushQueue.pop());
+            }
+        }
+
+        size = (size === -1) ? this.size() : size;
+
+        if (size > 0) {
+            tmp = (this._useUnique) ? this._getDataUnique(size) : this._data.splice(0, size);
+            data.push.apply(data, tmp);
         }
         if (data.length > 0) this.emit('flush', data);
     }
@@ -116,13 +140,18 @@ Buffering.prototype.size = function() {
     return (this._useUnique) ? this._objectLength : this._data.length;
 };
 
+Buffering.prototype.size_total = function() {
+    var s = (this._useUnique) ? this._objectLength : this._data.length;
+    return this._flushQueueSize + s;
+};
+
 Buffering.prototype._checkAndFlush = function() {
     if (this._flushingBySize) return;
     if (this._paused) return;
-    if (this._flushQueue.length > 0 || (this._sizeThreshold > 0 && this.size() >= this._sizeThreshold)) {
+    if (this._sizeThreshold > 0 && this.size_total() >= this._sizeThreshold) {
         this._flushingBySize = true;
         process.nextTick(this.flush.bind(this));
-    } else if (this._timeThreshold >= 0 && !this._flushTimer && this.size() > 0) {
+    } else if (this._timeThreshold >= 0 && !this._flushTimer && this.size_total() > 0) {
         this._flushTimer = setTimeout(this.flush.bind(this), this._timeThreshold);
     }
 };

--- a/lib/buffering.js
+++ b/lib/buffering.js
@@ -1,5 +1,7 @@
 var util = require('util');
 var events = require('events');
+var hasOwn = Object.prototype.hasOwnProperty;
+var objType = Object.prototype.toString; // ES 5+ will handle null and undefined
 
 function Buffering(options) {
     events.EventEmitter.call(this);
@@ -7,7 +9,10 @@ function Buffering(options) {
     options = options || {};
     this._timeThreshold = (typeof options.timeThreshold === 'undefined') ? -1 : options.timeThreshold;
     this._sizeThreshold = (typeof options.sizeThreshold === 'undefined') ? -1 : options.sizeThreshold;
-    this._data = [];
+    this._useUnique = (typeof options.useUnique === 'boolean') ? options.useUnique : false;
+    this._data = (this._useUnique) ? {} : [];
+    this._objectLength = 0;
+    this._flushQueue = [];
     this._flushTimer = null;
     this._paused = false;
     this._resumeTimer = null;
@@ -16,24 +21,79 @@ function Buffering(options) {
 
 util.inherits(Buffering, events.EventEmitter);
 
-Buffering.prototype.enqueue = function(data) {
+Buffering.prototype._enqueueUniqueSingle = function(key, value) {
+    if (!hasOwn.call(this._data, key)) ++this._objectLength;
+    this._data[key] = value;
+};
+
+Buffering.prototype._enqueueUniqueMultiple = function(data) {
+    for (var key in data) {
+        if (hasOwn.call(data, key)) this._enqueueUniqueSingle(data[key], data[key]);
+    }
+};
+
+Buffering.prototype._enqueueUniqueObject = function(data) {
+    for (var key in data) {
+        if (hasOwn.call(data, key)) this._enqueueUniqueSingle(key, data[key]);
+    }
+};
+
+Buffering.prototype._getDataUnique = function(size) {
+    var result = [];
+    for (var key in this._data) {
+        if (hasOwn.call(this._data, key)) {
+            result.push(this._data[key]);
+            delete this._data[key];
+            --this._objectLength;
+            if (--size <= 0) break;
+        }
+    }
+    return result;
+};
+
+Buffering.prototype._enqueueUnique = function(data) {
+    var data_type = objType.call(data);
+    switch (data_type) {
+        case '[object Object]':
+            this._enqueueUniqueObject(data); // specified key object
+            break;
+        case '[object Array]':
+            this._enqueueUniqueMultiple(data); // treat as multiple string
+            break;
+        default:
+            this._enqueueUniqueSingle(data, data); // treat as single string
+            break;
+    }
+
+    this._checkAndFlush();
+};
+
+Buffering.prototype._enqueue = function(data) {
     if (!(data instanceof Array)) data = [data];
     this._data.push.apply(this._data, data);
     this._checkAndFlush();
 };
 
+Buffering.prototype.enqueue = function(data) {
+    return (this._useUnique) ? this._enqueueUnique(data) : this._enqueue(data);
+};
+
 Buffering.prototype.undequeue = function(data) {
     if (!(data instanceof Array)) data = [data];
-    this._data.unshift.apply(this._data, data);
+    this._flushQueue.unshift.apply(this._flushQueue, data);
     this._checkAndFlush();
 };
 
 Buffering.prototype.flush = function() {
     var data;
     if (!this._paused) {
-        var size = (this._sizeThreshold > 0) ? this._sizeThreshold : this._data.length;
-        data = this._data.splice(0, size);
-        this.emit('flush', data);
+        if (this._flushQueue.length > 0) {
+            data = this._flushQueue.shift();
+        } else {
+            var size = (this._sizeThreshold > 0) ? this._sizeThreshold : this.size();
+            data = (this._useUnique) ? this._getDataUnique(size) : this._data.splice(0, size);
+        }
+        if (data.length > 0) this.emit('flush', data);
     }
     this._flushingBySize = false;
     this._clearTimer('_flushTimer');
@@ -53,17 +113,16 @@ Buffering.prototype.resume = function() {
 };
 
 Buffering.prototype.size = function() {
-    return this._data.length;
+    return (this._useUnique) ? this._objectLength : this._data.length;
 };
 
 Buffering.prototype._checkAndFlush = function() {
     if (this._flushingBySize) return;
     if (this._paused) return;
-    if (this._sizeThreshold > 0 && this._data.length >= this._sizeThreshold) {
+    if (this._flushQueue.length > 0 || (this._sizeThreshold > 0 && this.size() >= this._sizeThreshold)) {
         this._flushingBySize = true;
         process.nextTick(this.flush.bind(this));
-    }
-    else if (this._timeThreshold >= 0 && !this._flushTimer && this._data.length > 0) {
+    } else if (this._timeThreshold >= 0 && !this._flushTimer && this.size() > 0) {
         this._flushTimer = setTimeout(this.flush.bind(this), this._timeThreshold);
     }
 };


### PR DESCRIPTION
This feature is for buffering which have to be unique to specific key.
a common use case is when you want to log user's last activity to database in bulk way, or latest status such as presence status used in Instant Message.

this commit also implement a flushQueue to reduce re-ordering overhead when calling undequeue()
